### PR TITLE
Don't mark the answer as correct if the user enters the kanji reading in the meaning field for a vocab item

### DIFF
--- a/ios/AnswerChecker.swift
+++ b/ios/AnswerChecker.swift
@@ -269,8 +269,10 @@ class AnswerChecker: NSObject {
       let kanaText = TKMConvertKanaText(answer)
       switch checkAnswer(kanaText, subject: subject, studyMaterials: studyMaterials,
                          taskType: .reading, localCachingClient: localCachingClient) {
-      case .Precise, .Imprecise, .OtherKanjiReading:
+      case .Precise, .Imprecise:
         return .IsReadingButWantMeaning
+      case .OtherKanjiReading:
+        return .OtherKanjiReading
       default:
         break
       }


### PR DESCRIPTION
First, thanks for the great app.

I just ran into a bug where, if you enter a kanji reading in the meaning field for a vocab item, the item is marked as correct even though you provided an incorrect reading for the given item.

This PR fixes that issue by returning `OtherKanjiReading` from `checkAnswer` if the user enters the kanji reading in this situation. This causes the screen to shake but doesn't mark the reading as correct.

Repro:

君 vocab item
Enter "kun" (correct reading is きみ)
Hit enter, screen shakes.
Enter "buddy" (correct meaning)
Answer is accepted.

Expected behavior:

君 vocab item
Enter "kun" (correct reading is きみ)
Hit enter, screen shakes.
Enter "buddy" (correct meaning)
User moves onto reading portion.
